### PR TITLE
Update RemoteInt.h

### DIFF
--- a/IRremote/IRremoteInt.h
+++ b/IRremote/IRremoteInt.h
@@ -12,7 +12,12 @@
 #ifndef IRremoteint_h
 #define IRremoteint_h
 
+// To make it work with current and past versions of Arduino. Taken from Ken Shriff's RemoteInt.h
+#if defined(ARDUINO) && ARDUINO >= 100
+#include <Arduino.h>
+#else
 #include <WProgram.h>
+#endif
 
 #define CLKFUDGE 5      // fudge factor for clock interrupt overhead
 #define CLK 256      // max value for clock (timer 2)


### PR DESCRIPTION
Replaced:
# include "WProgram.h"

With:
# if defined(ARDUINO) && ARDUINO >= 100
# include "Arduino.h"
# else
# include "WProgram.h"
# endif

/_So that it can work with current and past versions of Arduino. Taken from Ken Shriff's original RemoteInt.h . Seems like you stuck with the NECIRrcv Library implementation of this._/
